### PR TITLE
DSO-56 🔧 Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# This CODEOWNERS file defines individuals or teams that are responsible
+# for code in this repository. Code owners are automatically requested
+# for review when someone opens a pull request that modifies code that
+# they own. Order is important; the last matching pattern takes the most
+# precedence.
+
+# A CODEOWNERS file uses a pattern that follows the same rules used in
+# gitignore files. The pattern is followed by one or more GitHub usernames
+# or team names using the standard @username or @org/team-name format.
+# You can also refer to a user by an email address that has been added
+# to their GitHub account, for example user@example.com.
+# https://help.github.com/articles/about-codeowners/
+
+* @SonyaMoisset


### PR DESCRIPTION
Same as web repo - all required files for GitHub open source will be under GitHub folder